### PR TITLE
Enable proper rendering of CHANGELOG.md on GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
 To contribute do the following:
+
 1. Check existing open issues.
 2. If not found, file an issue with any relevant information (versions, steps to reproduce, stacktrace, screenshots, etc).
 3. Fork repository.


### PR DESCRIPTION
The item list in CHANGELOG.md was not properly rendered. An empty lines solves the issue.