### PR TITLE
[WIP] Backport Dimitry Naumenko's changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ This library implements Myers' diff algorithm, but it is modular so it is easy t
 - add Guava to dependency
 - let user uses other string to represent line which does not exist
 - implement event based parser like SAX (in difflib.event package)
+
+### License
+
+The license of the library is Apache-2.0.
+Until version 1.3.1, the license was Apache-1.1.
+The files in the directory `java-diff-utils-lib/src/main/java/difflib/myers` are subject to LGPL-2.1.

--- a/java-diff-utils-lib/src/main/java/difflib/myers/DiffNode.java
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/DiffNode.java
@@ -34,8 +34,8 @@ public final class DiffNode extends PathNode {
      * will be followed using {@link PathNode#previousSnake}
      * until a non-diff node is found.
      *
-     * @param the position in the original sequence
-     * @param the position in the revised sequence
+     * @param i position in the original sequence
+     * @param j position in the revised sequence
      * @param prev the previous node in the path.
      */
     public DiffNode(int i, int j, PathNode prev) {

--- a/java-diff-utils-lib/src/main/java/difflib/myers/MyersDiff.java
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/MyersDiff.java
@@ -72,7 +72,7 @@ import java.util.List;
  * http://www.cs.arizona.edu/people/gene/PAPERS/diff.ps</a></p>
  *
  * @author <a href="mailto:juanco@suigeneris.org">Juanco Anez</a>
- * @param T The type of the compared elements in the 'lines'.
+ * T The type of the compared elements in the 'lines'.
  */
 public class MyersDiff<T> implements DiffAlgorithm<T> {
   /** Default equalizer. */

--- a/java-diff-utils-lib/src/main/java/difflib/myers/MyersDiff.java
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/MyersDiff.java
@@ -72,7 +72,7 @@ import java.util.List;
  * http://www.cs.arizona.edu/people/gene/PAPERS/diff.ps</a></p>
  *
  * @author <a href="mailto:juanco@suigeneris.org">Juanco Anez</a>
- * T The type of the compared elements in the 'lines'.
+ * @param <T> The type of the compared elements in the 'lines'.
  */
 public class MyersDiff<T> implements DiffAlgorithm<T> {
   /** Default equalizer. */

--- a/java-diff-utils-lib/src/main/java/difflib/myers/Snake.java
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/Snake.java
@@ -74,8 +74,8 @@ public final class Snake extends PathNode {
     /**
      * Constructs a snake node.
      *
-     * @param the position in the original sequence
-     * @param the position in the revised sequence
+     * @param i position in the original sequence
+     * @param j position in the revised sequence
      * @param prev the previous node in the path.
      */
     public Snake(int i, int j, PathNode prev) {

--- a/java-diff-utils-lib/src/main/java/difflib/myers/package.html
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/package.html
@@ -1,23 +1,58 @@
 <!DOCTYPE html PUBLIC "-//IETF//DTD HTML 2.0//EN">
 <!--
-/*
-    Copyright 2009 Dmitry Naumenko (dm.naumenko@gmail.com)
-    
-    This file is part of Java Diff Utills Library.
-
-    Java Diff Utills Library is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    Java Diff Utills Library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with Java Diff Utills Library.  If not, see <http://www.gnu.org/licenses/>.
-*/
+/* ====================================================================
+ * The Apache Software License, Version 1.1
+ *
+ * Copyright (c) 2002 The Apache Software Foundation.  All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution,
+ *    if any, must include the following acknowledgment:
+ *       "This product includes software developed by the
+ *        Apache Software Foundation (http://www.apache.org/)."
+ *    Alternately, this acknowledgment may appear in the software itself,
+ *    if and wherever such third-party acknowledgments normally appear.
+ *
+ * 4. The names "Apache" and "Apache Software Foundation" and
+ *    "Apache Maven" must not be used to endorse or promote products
+ *    derived from this software without prior written permission. For
+ *    written permission, please contact apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache",
+ *    "Apache Maven", nor may "Apache" appear in their name, without
+ *    prior written permission of the Apache Software Foundation.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ */
  -->
 <html>
   <head>

--- a/java-diff-utils-lib/src/main/java/difflib/myers/package.html
+++ b/java-diff-utils-lib/src/main/java/difflib/myers/package.html
@@ -1,67 +1,10 @@
-<!DOCTYPE html PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<!--
-/* ====================================================================
- * The Apache Software License, Version 1.1
- *
- * Copyright (c) 2002 The Apache Software Foundation.  All rights
- * reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- * 3. The end-user documentation included with the redistribution,
- *    if any, must include the following acknowledgment:
- *       "This product includes software developed by the
- *        Apache Software Foundation (http://www.apache.org/)."
- *    Alternately, this acknowledgment may appear in the software itself,
- *    if and wherever such third-party acknowledgments normally appear.
- *
- * 4. The names "Apache" and "Apache Software Foundation" and
- *    "Apache Maven" must not be used to endorse or promote products
- *    derived from this software without prior written permission. For
- *    written permission, please contact apache@apache.org.
- *
- * 5. Products derived from this software may not be called "Apache",
- *    "Apache Maven", nor may "Apache" appear in their name, without
- *    prior written permission of the Apache Software Foundation.
- *
- * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
- * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
- * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
- * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- * ====================================================================
- *
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation.  For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
- */
- -->
-<html>
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
   <head>
-    <meta name="generator" content=
-    "HTML Tidy for Cygwin (vers 1st February 2003), see www.w3.org">
-    <title></title>
+    <title>difflib.myers</title>
   </head>
   <body>
-      <p>
+    <p>
       The {@link difflib.myers diff.myers} package
       implements  <a href=
       "http://www.cs.arizona.edu/people/gene/">Gene Myers</a>'
@@ -72,6 +15,11 @@
       consumes considerably more memory than SimpleDiff, so its not
       suitable for very large files.
     </p>
-@author <a href="mailto:juanco@suigeneris.org">Juanco Anez</a>
+    <p>
+      @author <a href="mailto:juanco@suigeneris.org">Juanco Anez</a>
+    </p>
+    <p>
+      In an email on 2012-12-17, Juancarlo Añez clearly stated that the license of the files in this directory is LGPL-2.1.
+    </p>
   </body>
 </html>


### PR DESCRIPTION
I discovered that Dimitry made his own fork: https://github.com/dnaumenko/java-diff-utils. It seems that he did not use the functionality of GitHub. The first commit is missing at his repo and also the author mapping is different. So, the commit ids all differ. The last common commits are 52bb97bda3b2324b27541231302 and https://github.com/dnaumenko/java-diff-utils/commit/8ceaaccf274cfaefd6fb68961b respectively. 

This commit picks the improvement he made in https://github.com/dnaumenko/java-diff-utils/commit/bdaf7e81e30a6d3ea924eff2f0d925d38c86e0bf

The most important change is to clarify the license of the source files. Dimitry released his part at Apache-1.1. Here in this repo, it was changed to Apache-2.0. I think, the original authors should be ask whether they agree on this change. As this does not change the general intention (no copyleft), I would not see that as a big issue.

<s>The myers part, however, is an issue. The original author stated that he wants his code licensed as LGPL-2.1 as stated at https://code.google.com/archive/p/jrcs/. One can browse the copied code at https://github.com/tarzanek/jrcs/tree/master/src/java/org/suigeneris/jrcs/diff/myers.</s>

<s>A quick solution to this issue is just to mention the different licenses. I wrote Juan Carlo an email whether it is OK for him to change the license of the code. Knowing of a discussion 4 years ago, I think, he wants to keep LPGL-2.1.</s>

Thus, in the long run, one has to offer his Myers implementation and the contributions of others to that library as separate library. Then, java-diff-utils can be based on this library and keep its Apache-2.0 license.